### PR TITLE
IA-3889: adding missing roles and bumping up TF version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Releases
 
+# v7.0.0
+- [BREAKING] Module now requires terraform ~> 1.9
+- We have added necessary roles to the backup policy
+  - AWSBackupServiceRolePolicyForS3Restore
+  - AWSBackupServiceRolePolicyForRestores
+- Module now can handle restore to s3 and EFS mounts. 
+
 # v6.0.0
 - Module now requires terraform~>1.5 and provider~>5.0
 

--- a/backup_iam_principal.tf
+++ b/backup_iam_principal.tf
@@ -25,3 +25,15 @@ resource "aws_iam_role_policy_attachment" "s3_service_role_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
   role       = var.enabled ? aws_iam_role.service_role[0].name : ""
 }
+
+resource "aws_iam_role_policy_attachment" "restore_service_role_attachment" {
+  count      = local.enabled_count
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+  role       = var.enabled ? aws_iam_role.service_role[0].name : ""
+}
+
+resource "aws_iam_role_policy_attachment" "s3_restore_service_role_attachment" {
+  count      = local.enabled_count
+  policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore"
+  role       = var.enabled ? aws_iam_role.service_role[0].name : ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
IA-3889:
- [BREAKING] Module now requires terraform ~> 1.9
- We have added necessary roles to the backup policy
- Module now can handle restore to s3 and EFS mounts. 